### PR TITLE
Don't use len(X) - it doesn't work for sparse matrices, use X.shape[0]

### DIFF
--- a/pylightgbm/models.py
+++ b/pylightgbm/models.py
@@ -265,7 +265,7 @@ class GBMClassifier(GenericGMB, ClassifierMixin):
         with open(output_model, mode="w") as file:
             file.write(self.model)
 
-        datasets.dump_svmlight_file(X, np.zeros(len(X)), f=predict_filepath)
+        datasets.dump_svmlight_file(X, np.zeros(X.shape[0]), f=predict_filepath)
 
         calls = [
             "task = predict\n",


### PR DESCRIPTION
`len(X)` results in error when `X` is sparse matrix:

```
TypeError: sparse matrix length is ambiguous; use getnnz() or shape[0]
```

So, to get amount of row it's better to use `X.shape[0]` - after this change the code works with both sparse and dense without any problems.